### PR TITLE
Add support for virtuals autopopulate

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var mongoose = require('mongoose');
 
 module.exports = function(schema) {
   var pathsToPopulate = [];
+
   eachPathRecursive(schema, function(pathname, schemaType) {
     var option;
     if (schemaType.options && schemaType.options.autopopulate) {
@@ -18,6 +19,15 @@ module.exports = function(schema) {
       pathsToPopulate.push({
         options: defaultOptions(pathname, schemaType.options.type[0]),
         autopopulate: option
+      });
+    }
+  });
+
+  Object.keys(schema.virtuals).forEach(function(pathname) {
+    if (schema.virtuals[pathname].options.autopopulate) {
+      pathsToPopulate.push({
+        options: defaultOptions(pathname, schema.virtuals[pathname].options),
+        autopopulate: schema.virtuals[pathname].options.autopopulate,
       });
     }
   });

--- a/index.js
+++ b/index.js
@@ -23,14 +23,16 @@ module.exports = function(schema) {
     }
   });
 
-  Object.keys(schema.virtuals).forEach(function(pathname) {
-    if (schema.virtuals[pathname].options.autopopulate) {
-      pathsToPopulate.push({
-        options: defaultOptions(pathname, schema.virtuals[pathname].options),
-        autopopulate: schema.virtuals[pathname].options.autopopulate,
-      });
-    }
-  });
+  if (schema.virtuals) {
+    Object.keys(schema.virtuals).forEach(function(pathname) {
+      if (schema.virtuals[pathname].options.autopopulate) {
+        pathsToPopulate.push({
+          options: defaultOptions(pathname, schema.virtuals[pathname].options),
+          autopopulate: schema.virtuals[pathname].options.autopopulate,
+        });
+      }
+    });
+  }
 
   var autopopulateHandler = function() {
     var numPaths = pathsToPopulate.length;


### PR DESCRIPTION
This patchs adds the ability to autopopulate Virtuals Populate.

Suppose you have a User schema and you want to automatically populate the 5 most recent user sessions which are stored in the Session schema.

```
// Dynamically populate sessions virtual
userSchema.virtual('sessions', {
  ref: 'Session',
  localField: '_id',
  foreignField: 'user',
  autopopulate: { options: { sort: { date: -1 }, limit: 2 }},
});
```

Feedbacks and comments are welcome. Helps for the tests and updating README would very much be appreciated.

Closes #23 