### PR TITLE
feat: allows override of maxDepth param via query options

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,14 +50,13 @@ module.exports = function(schema) {
       return;
     }
 
-    let maxDepth = options.maxDepth;
-
     if (options.autopopulate && options.autopopulate.maxDepth) {
-    	maxDepth = options.autopopulate.maxDepth;
+    	options.maxDepth = options.autopopulate.maxDepth;
     }
 
     const depth = options._depth != null ? options._depth : 0;
-    if (maxDepth > 0 && depth >= maxDepth) {
+
+    if (options.maxDepth > 0 && depth >= options.maxDepth) {
       return;
     }
 
@@ -69,12 +68,9 @@ module.exports = function(schema) {
       }
       pathsToPopulate[i].options.options = pathsToPopulate[i].options.options || {};
 
-      Object.assign(pathsToPopulate[i].options.options, {
-        _depth: depth + 1,
-        autopopulate: {
-          maxDepth: maxDepth,
-        },
-      });
+      const newOptions = { _depth: depth + 1 }
+      if (options.maxDepth) newOptions.maxDepth = options.maxDepth;
+      Object.assign(pathsToPopulate[i].options.options, newOptions);
 
       processOption.call(this,
         pathsToPopulate[i].autopopulate, pathsToPopulate[i].options);

--- a/index.js
+++ b/index.js
@@ -50,8 +50,14 @@ module.exports = function(schema) {
       return;
     }
 
+    let maxDepth = options.maxDepth;
+
+    if (options.autopopulate && options.autopopulate.maxDepth) {
+    	maxDepth = options.autopopulate.maxDepth;
+    }
+
     const depth = options._depth != null ? options._depth : 0;
-    if (options.maxDepth > 0 && depth >= options.maxDepth) {
+    if (maxDepth > 0 && depth >= maxDepth) {
       return;
     }
 
@@ -62,7 +68,14 @@ module.exports = function(schema) {
         continue;
       }
       pathsToPopulate[i].options.options = pathsToPopulate[i].options.options || {};
-      Object.assign(pathsToPopulate[i].options.options, { _depth: depth + 1 });
+
+      Object.assign(pathsToPopulate[i].options.options, {
+        _depth: depth + 1,
+        autopopulate: {
+          maxDepth: maxDepth,
+        },
+      });
+
       processOption.call(this,
         pathsToPopulate[i].autopopulate, pathsToPopulate[i].options);
     }


### PR DESCRIPTION
This PR allows you to override the `maxDepth` option on a query by query basis via query options.