### PR TITLE
Exit early from autopopulate save hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ module.exports = function(schema) {
     post('findOne', function(res) { return autopopulateDiscriminators.call(this, res) }).
     post('findOneAndUpdate', function(res) { return autopopulateDiscriminators.call(this, res) }).
     post('save', function() {
-      if (pathsToPopulate.length < 0) {
+      if (pathsToPopulate.length === 0) {
         return Promise.resolve();
       }
       autopopulateHandler.call(this, options => {


### PR DESCRIPTION
Ran into an issue where `execPopulate` was being run on a subdoc when it shouldn't have been, causing this error:
```
Mongoose does not support calling populate() on nested docs. Instead of `doc.nested.populate("path")`, use `doc.populate("nested.path")`
```

Wasn't able to reproduce that specific error in the tests here, or otherwise think of a good way to test this besides spying on execPopulate. Any ideas?