### PR TITLE
feat: add native type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,5 @@
+import { Schema } from 'mongoose';
+
+declare function mongooseAutoPopulate(schema: Schema): void;
+
+export default mongooseAutoPopulate;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "peerDependencies": {
     "mongoose": ">= 5.12.4"
   },
+  "types": "./index.d.ts",
   "author": "Valeri Karpov <val@karpov.io>",
   "license": "Apache 2.0",
   "bugs": {


### PR DESCRIPTION
This PR solves #91.

Mongoose provides native type definitions (since 5.11). When using TypeScript and mongoose-autopopulate you have to install @types/mongoose-autopopulate which has dependencies to @types/mongoose. This is not compatible to mongoose >= 5.11.
Using native type definitions solves the compatibility issue.