### PR TITLE
Fix post save hook to work with mongoose 6.2 resolving issue #94

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ module.exports = function autopopulatePlugin(schema, options) {
       }
       // Skip for subdocs, because we assume this function only runs on
       // top-level documents.
-      if (typeof this.ownerDocument === 'function') {
+      if (this.ownerDocument() !== this) {
         return Promise.resolve();
       }
       const finalPaths = autopopulateHandler.call(this, options => {


### PR DESCRIPTION
This PR resolves issue #94 - `this.ownerDocument` inside of `post("save")` is always a function in latest versions of mongoose